### PR TITLE
Generic Query & Update

### DIFF
--- a/Sources/TranslationCatalog/Catalog.swift
+++ b/Sources/TranslationCatalog/Catalog.swift
@@ -76,8 +76,3 @@ public protocol Catalog {
     /// - parameter id: The unique identifier for the `Translation`.
     func deleteTranslation(_ id: Translation.ID) throws
 }
-
-/// Associated parameters when performing update operations
-public protocol CatalogUpdate {}
-/// Associated parameters for performing query operations
-public protocol CatalogQuery {}

--- a/Sources/TranslationCatalog/CatalogQuery.swift
+++ b/Sources/TranslationCatalog/CatalogQuery.swift
@@ -1,0 +1,30 @@
+import Foundation
+import LocaleSupport
+
+/// Associated parameters for performing query operations
+public protocol CatalogQuery {}
+
+public enum GenericProjectQuery: CatalogQuery {
+    case id(Project.ID)
+    case named(String)
+}
+
+public enum GenericExpressionQuery: CatalogQuery {
+    case id(Expression.ID)
+    case projectID(Project.ID)
+    case key(String)
+    case named(String)
+    /// Expressions with Translations that only match the provided LanguageCode. (Script == Null & Region == Null)
+    case translationsHavingOnly(LanguageCode)
+    /// Expressions with Translations the match the LanguageCode as well as the provided script/region.
+    case translationsHaving(LanguageCode, ScriptCode?, RegionCode?)
+}
+
+public enum GenericTranslationQuery: CatalogQuery {
+    case id(Translation.ID)
+    case expressionID(Expression.ID)
+    /// Translations that match only the given parameters (Script == Null & Region == Null)
+    case havingOnly(Expression.ID, LanguageCode)
+    /// Translations that match all of the provided parameters
+    case having(Expression.ID, LanguageCode, ScriptCode?, RegionCode?)
+}

--- a/Sources/TranslationCatalog/CatalogUpdate.swift
+++ b/Sources/TranslationCatalog/CatalogUpdate.swift
@@ -1,0 +1,26 @@
+import Foundation
+import LocaleSupport
+
+/// Associated parameters when performing update operations
+public protocol CatalogUpdate {}
+
+public enum GenericProjectUpdate: CatalogUpdate {
+    case name(String)
+    case linkExpression(Expression.ID)
+    case unlinkExpression(Expression.ID)
+}
+
+public enum GenericExpressionUpdate: CatalogUpdate {
+    case key(String)
+    case name(String)
+    case defaultLanguage(LanguageCode)
+    case context(String?)
+    case feature(String?)
+}
+
+public enum GenericTranslationUpdate: CatalogUpdate {
+    case language(LanguageCode)
+    case script(ScriptCode?)
+    case region(RegionCode?)
+    case value(String)
+}

--- a/Sources/TranslationCatalogSQLite/SQLiteCatalog+AssociatedTypes.swift
+++ b/Sources/TranslationCatalogSQLite/SQLiteCatalog+AssociatedTypes.swift
@@ -15,6 +15,7 @@ public extension SQLiteCatalog {
         case existingExpressionWithID(Expression.ID)
         case existingExpressionWithKey(String)
         case existingTranslationWithID(TranslationCatalog.Translation.ID)
+        case unhandledAction(CatalogUpdate)
         case unhandledQuery(CatalogQuery)
         case unhandledConversion
     }
@@ -22,53 +23,79 @@ public extension SQLiteCatalog {
     enum ProjectQuery: CatalogQuery {
         case hierarchy
         case primaryKey(Int)
+        @available(*, deprecated, renamed: "GenericProjectQuery.id")
         case id(Project.ID)
+        @available(*, deprecated, renamed: "GenericProjectQuery.named")
         case named(String)
     }
     
     enum ExpressionQuery: CatalogQuery {
         case hierarchy
         case primaryKey(Int)
+        @available(*, deprecated, renamed: "GenericExpressionQuery.id")
         case id(Expression.ID)
+        @available(*, deprecated, renamed: "GenericExpressionQuery.projectID")
         case projectID(Project.ID)
+        @available(*, deprecated, renamed: "GenericExpressionQuery.key")
         case key(String)
+        @available(*, deprecated, renamed: "GenericExpressionQuery.named")
         case named(String)
         /// Expressions with Translations the match the LanguageCode as well as the provided script/region.
+        @available(*, deprecated, renamed: "GenericExpressionQuery.translationsHaving")
         case having(LanguageCode, ScriptCode?, RegionCode?)
         /// Expressions with Translations that only match the provided LanguageCode. (Script == Null & Region == Null)
+        @available(*, deprecated, renamed: "GenericExpressionQuery.translationsHavingOnly")
         case havingOnly(LanguageCode)
     }
     
     enum TranslationQuery: CatalogQuery {
         case primaryKey(Int)
+        @available(*, deprecated, renamed: "GenericTranslationQuery.id")
         case id(TranslationCatalog.Translation.ID)
+        @available(*, deprecated, renamed: "GenericTranslationQuery.expressionID")
         case expressionID(Expression.ID)
         /// Translations that match all of the provided parameters
+        @available(*, deprecated, renamed: "GenericTranslationQuery.having")
         case having(Expression.ID, LanguageCode, ScriptCode?, RegionCode?)
         /// Translations that match only the given parameters (Script == Null & Region == Null)
+        @available(*, deprecated, renamed: "GenericTranslationQuery.havingOnly")
         case havingOnly(Expression.ID, LanguageCode)
     }
     
     enum ProjectUpdate: CatalogUpdate {
+        @available(*, deprecated, renamed: "GenericProjectUpdate.name")
         case name(String)
+        @available(*, deprecated, renamed: "GenericProjectUpdate.linkExpression")
         case linkExpression(Expression.ID)
+        @available(*, deprecated, renamed: "GenericProjectUpdate.unlinkExpression")
         case unlinkExpression(Expression.ID)
     }
     
     enum ExpressionUpdate: CatalogUpdate {
+        @available(*, deprecated, renamed: "GenericExpressionUpdate.key")
         case key(String)
+        @available(*, deprecated, renamed: "GenericExpressionUpdate.name")
         case name(String)
+        @available(*, deprecated, renamed: "GenericExpressionUpdate.defaultLanguage")
         case defaultLanguage(LanguageCode)
+        @available(*, deprecated, renamed: "GenericExpressionUpdate.context")
         case context(String?)
+        @available(*, deprecated, renamed: "GenericExpressionUpdate.feature")
         case feature(String?)
+        @available(*, deprecated, renamed: "GenericProjectUpdate.linkExpression")
         case linkProject(Project.ID)
+        @available(*, deprecated, renamed: "GenericProjectUpdate.unlinkExpression")
         case unlinkProject(Project.ID)
     }
     
     enum TranslationUpdate: CatalogUpdate {
+        @available(*, deprecated, renamed: "GenericTranslationUpdate.language")
         case language(LanguageCode)
+        @available(*, deprecated, renamed: "GenericTranslationUpdate.script")
         case script(ScriptCode?)
+        @available(*, deprecated, renamed: "GenericTranslationUpdate.region")
         case region(RegionCode?)
+        @available(*, deprecated, renamed: "GenericTranslationUpdate.value")
         case value(String)
     }
 }

--- a/Sources/TranslationCatalogSQLite/SQLiteCatalog.swift
+++ b/Sources/TranslationCatalogSQLite/SQLiteCatalog.swift
@@ -226,6 +226,12 @@ public class SQLiteCatalog: TranslationCatalog.Catalog {
             }
             
             return try entity.expression()
+        case .key(let key):
+            guard let entity = try db.expressionEntity(statement: renderStatement(.selectExpression(withKey: key))) else {
+                throw Error.invalidQuery(query)
+            }
+            
+            return try entity.expression()
         default:
             throw Error.unhandledQuery(query)
         }

--- a/Sources/localizer/Catalog+Export.swift
+++ b/Sources/localizer/Catalog+Export.swift
@@ -55,26 +55,26 @@ extension Catalog {
             switch format {
             case .android:
                 if let id = projectId {
-                    expressions = try catalog.expressions(matching: SQLiteCatalog.ExpressionQuery.projectID(id))
-                    let withLanguage = try catalog.expressions(matching: SQLiteCatalog.ExpressionQuery.having(language, script, region))
+                    expressions = try catalog.expressions(matching: GenericExpressionQuery.projectID(id))
+                    let withLanguage = try catalog.expressions(matching: GenericExpressionQuery.translationsHaving(language, script, region))
                     expressions.removeAll { expression in
                         !withLanguage.contains(where: { $0.id == expression.id })
                     }
                 } else {
-                    expressions = try catalog.expressions(matching: SQLiteCatalog.ExpressionQuery.having(language, script, region))
+                    expressions = try catalog.expressions(matching: GenericExpressionQuery.translationsHaving(language, script, region))
                 }
                 
                 expressionIds = expressions.map { $0.id }
                 
                 try expressionIds.enumerated().forEach { (index, id) in
-                    expressions[index].translations = try catalog.translations(matching: SQLiteCatalog.TranslationQuery.having(id, language, script, region))
+                    expressions[index].translations = try catalog.translations(matching: GenericTranslationQuery.having(id, language, script, region))
                 }
                 
                 exportAndroid(expressions)
             case .apple:
                 if let id = projectId {
-                    expressions = try catalog.expressions(matching: SQLiteCatalog.ExpressionQuery.projectID(id))
-                    let withLanguage = try catalog.expressions(matching: SQLiteCatalog.ExpressionQuery.having(language, nil, nil))
+                    expressions = try catalog.expressions(matching: GenericExpressionQuery.projectID(id))
+                    let withLanguage = try catalog.expressions(matching: GenericExpressionQuery.translationsHaving(language, nil, nil))
                     expressions.removeAll { expression in
                         !withLanguage.contains(where: { $0.id == expression.id })
                     }
@@ -85,20 +85,20 @@ extension Catalog {
                 expressionIds = expressions.map { $0.id }
                 
                 for (index, id) in expressionIds.enumerated() {
-                    let preferredTranslations = try catalog.translations(matching: SQLiteCatalog.TranslationQuery.having(id, language, script, region))
+                    let preferredTranslations = try catalog.translations(matching: GenericTranslationQuery.having(id, language, script, region))
                     if !preferredTranslations.isEmpty {
                         expressions[index].translations = preferredTranslations
                         continue
                     }
                     
-                    let fallbackTranslations = try catalog.translations(matching: SQLiteCatalog.TranslationQuery.having(id, language, nil, nil))
+                    let fallbackTranslations = try catalog.translations(matching: GenericTranslationQuery.having(id, language, nil, nil))
                     if !fallbackTranslations.isEmpty {
                         expressions[index].translations = fallbackTranslations
                         continue
                     }
                     
                     let defaultLanguage = expressions[index].defaultLanguage
-                    let defaultTranslations = try catalog.translations(matching: SQLiteCatalog.TranslationQuery.having(id, defaultLanguage, nil, nil))
+                    let defaultTranslations = try catalog.translations(matching: GenericTranslationQuery.having(id, defaultLanguage, nil, nil))
                     expressions[index].translations = defaultTranslations
                 }
                 

--- a/Sources/localizer/Catalog+Import.swift
+++ b/Sources/localizer/Catalog+Import.swift
@@ -100,7 +100,7 @@ extension Catalog {
         }
         
         private func importTranslations(_ expression: Expression, into catalog: SQLiteCatalog) {
-            guard let id = try? catalog.expression(matching: SQLiteCatalog.ExpressionQuery.key(expression.key)).id else {
+            guard let id = try? catalog.expression(matching: GenericExpressionQuery.key(expression.key)).id else {
                 return
             }
             

--- a/Sources/localizer/Catalog+Import.swift
+++ b/Sources/localizer/Catalog+Import.swift
@@ -83,9 +83,41 @@ extension Catalog {
                 expressions = dictionary.expressions(defaultLanguage: defaultLanguage, language: language, script: script, region: region)
             }
             
-            try expressions.forEach({
-                try catalog.createExpression($0)
+            expressions.forEach({
+                importExpression($0, into: catalog)
             })
+        }
+        
+        private func importExpression(_ expression: Expression, into catalog: SQLiteCatalog) {
+            do {
+                try catalog.createExpression(expression)
+                print("Imported Expression '\(expression.name)'")
+            } catch SQLiteCatalog.Error.existingExpressionWithKey {
+                importTranslations(expression, into: catalog)
+            } catch {
+                print("Import Failure: \(expression); \(error.localizedDescription)")
+            }
+        }
+        
+        private func importTranslations(_ expression: Expression, into catalog: SQLiteCatalog) {
+            guard let id = try? catalog.expression(matching: SQLiteCatalog.ExpressionQuery.key(expression.key)).id else {
+                return
+            }
+            
+            expression.translations.forEach { translation in
+                var t = translation
+                t.expressionID = id
+                importTranslation(t, into: catalog)
+            }
+        }
+        
+        private func importTranslation(_ translation: TranslationCatalog.Translation, into catalog: SQLiteCatalog) {
+            do {
+                try catalog.createTranslation(translation)
+                print("Imported Translation '\(translation.value)'")
+            } catch {
+                print("Import Failure: \(translation); \(error.localizedDescription)")
+            }
         }
     }
 }

--- a/Sources/localizer/Catalog+Query.swift
+++ b/Sources/localizer/Catalog+Query.swift
@@ -63,7 +63,7 @@ extension Catalog.Query {
             var projects: [Project] = []
             
             if let named = self.named {
-                projects = try catalog.projects(matching: SQLiteCatalog.ProjectQuery.named(named))
+                projects = try catalog.projects(matching: GenericProjectQuery.named(named))
             } else {
                 projects = try catalog.projects()
             }
@@ -121,9 +121,9 @@ extension Catalog.Query {
             var expressions: [Expression] = []
             
             if let key = self.key {
-                expressions = try catalog.expressions(matching: SQLiteCatalog.ExpressionQuery.key(key))
+                expressions = try catalog.expressions(matching: GenericExpressionQuery.key(key))
             } else if let named = self.named {
-                expressions = try catalog.expressions(matching: SQLiteCatalog.ExpressionQuery.named(named))
+                expressions = try catalog.expressions(matching: GenericExpressionQuery.named(named))
             } else {
                 expressions = try catalog.expressions()
             }

--- a/Sources/localizer/Catalog+Update.swift
+++ b/Sources/localizer/Catalog+Update.swift
@@ -76,17 +76,17 @@ extension Catalog.Update {
             print("Updating Project '\(project.name) [\(project.uuid.uuidString)]'…")
             
             if let name = self.name {
-                try catalog.updateProject(project.id, action: SQLiteCatalog.ProjectUpdate.name(name))
+                try catalog.updateProject(project.id, action: GenericProjectUpdate.name(name))
                 print("Set Name to '\(name)'.")
             }
             
             if let link = linkExpression {
-                try catalog.updateProject(project.id, action: SQLiteCatalog.ProjectUpdate.linkExpression(link))
+                try catalog.updateProject(project.id, action: GenericProjectUpdate.linkExpression(link))
                 print("Created link to expression '\(link.uuidString)'.")
             }
             
             if let unlink = unlinkExpression {
-                try catalog.updateProject(project.id, action: SQLiteCatalog.ProjectUpdate.unlinkExpression(unlink))
+                try catalog.updateProject(project.id, action: GenericProjectUpdate.unlinkExpression(unlink))
                 print("Removed link from expression '\(unlink.uuidString)'.")
             }
         }
@@ -160,33 +160,33 @@ extension Catalog.Update {
             let expression = try catalog.expression(id)
             
             if let key = self.key, expression.key != key {
-                try catalog.updateExpression(expression.id, action: SQLiteCatalog.ExpressionUpdate.key(key))
+                try catalog.updateExpression(expression.id, action: GenericExpressionUpdate.key(key))
             }
             
             if let name = self.name, expression.name != name {
-                try catalog.updateExpression(expression.id, action: SQLiteCatalog.ExpressionUpdate.name(name))
+                try catalog.updateExpression(expression.id, action: GenericExpressionUpdate.name(name))
             }
             
             if let language = self.defaultLanguage, expression.defaultLanguage != language {
-                try catalog.updateExpression(expression.id, action: SQLiteCatalog.ExpressionUpdate.defaultLanguage(language))
+                try catalog.updateExpression(expression.id, action: GenericExpressionUpdate.defaultLanguage(language))
             }
             
             if let context = self.context, expression.context != context {
                 let value = context.isEmpty ? nil : context
-                try catalog.updateExpression(expression.id, action: SQLiteCatalog.ExpressionUpdate.context(value))
+                try catalog.updateExpression(expression.id, action: GenericExpressionUpdate.context(value))
             }
             
             if let feature = self.feature, expression.feature != feature {
                 let value = feature.isEmpty ? nil : feature
-                try catalog.updateExpression(expression.id, action: SQLiteCatalog.ExpressionUpdate.feature(value))
+                try catalog.updateExpression(expression.id, action: GenericExpressionUpdate.feature(value))
             }
             
             if let link = linkProject {
-                try catalog.updateExpression(expression.id, action: SQLiteCatalog.ExpressionUpdate.linkProject(link))
+                try catalog.updateProject(link, action: GenericProjectUpdate.linkExpression(expression.id))
             }
             
             if let unlink = unlinkProject {
-                try catalog.updateExpression(expression.id, action: SQLiteCatalog.ExpressionUpdate.unlinkProject(unlink))
+                try catalog.updateProject(unlink, action: GenericProjectUpdate.unlinkExpression(expression.id))
             }
         }
     }
@@ -244,27 +244,27 @@ extension Catalog.Update {
             let translation = try catalog.translation(id)
             
             if let language = self.language, translation.languageCode != language {
-                try catalog.updateTranslation(translation.id, action: SQLiteCatalog.TranslationUpdate.language(language))
+                try catalog.updateTranslation(translation.id, action: GenericTranslationUpdate.language(language))
             }
             
             if let script = self.script, translation.scriptCode != script {
-                try catalog.updateTranslation(translation.id, action: SQLiteCatalog.TranslationUpdate.script(script))
+                try catalog.updateTranslation(translation.id, action: GenericTranslationUpdate.script(script))
             }
             
             if let region = self.region, translation.regionCode != region {
-                try catalog.updateTranslation(translation.id, action: SQLiteCatalog.TranslationUpdate.region(region))
+                try catalog.updateTranslation(translation.id, action: GenericTranslationUpdate.region(region))
             }
             
             if let value = self.value, translation.value != value {
-                try catalog.updateTranslation(translation.id, action: SQLiteCatalog.TranslationUpdate.value(value))
+                try catalog.updateTranslation(translation.id, action: GenericTranslationUpdate.value(value))
             }
             
             if dropScript && script == nil {
-                try catalog.updateTranslation(translation.id, action: SQLiteCatalog.TranslationUpdate.script(nil))
+                try catalog.updateTranslation(translation.id, action: GenericTranslationUpdate.script(nil))
             }
             
             if dropRegion && region == nil {
-                try catalog.updateTranslation(translation.id, action: SQLiteCatalog.TranslationUpdate.region(nil))
+                try catalog.updateTranslation(translation.id, action: GenericTranslationUpdate.region(nil))
             }
         }
     }

--- a/Tests/TranslationCatalogSQLiteTests/CatalogDeleteTests.swift
+++ b/Tests/TranslationCatalogSQLiteTests/CatalogDeleteTests.swift
@@ -121,7 +121,7 @@ final class CatalogDeleteTests: _CatalogTestCase {
         func preConditions(catalog: SQLiteCatalog) throws {
             try catalog.createProject(project)
             try catalog.createExpression(expression)
-            try catalog.updateExpression(expressionId, action: SQLiteCatalog.ExpressionUpdate.linkProject(projectId))
+            try catalog.updateProject(projectId, action: GenericProjectUpdate.linkExpression(expressionId))
             let projects = try catalog.projects()
             XCTAssertEqual(projects.count, 1)
             let expressions = try catalog.expressions()

--- a/Tests/TranslationCatalogSQLiteTests/CatalogQueryTests.swift
+++ b/Tests/TranslationCatalogSQLiteTests/CatalogQueryTests.swift
@@ -123,9 +123,9 @@ final class CatalogQueryTests: _CatalogTestCase {
     }
     
     func testQueryProjectsNamed() throws {
-        var projects = try catalog.projects(matching: SQLiteCatalog.ProjectQuery.named("shop"))
+        var projects = try catalog.projects(matching: GenericProjectQuery.named("shop"))
         XCTAssertEqual(projects.count, 2)
-        projects = try catalog.projects(matching: SQLiteCatalog.ProjectQuery.named("class"))
+        projects = try catalog.projects(matching: GenericProjectQuery.named("class"))
         XCTAssertEqual(projects.count, 2)
     }
     
@@ -140,8 +140,8 @@ final class CatalogQueryTests: _CatalogTestCase {
     }
     
     func testQueryProjectNamed() throws {
-        XCTAssertThrowsError(try catalog.project(matching: SQLiteCatalog.ProjectQuery.named("class")))
-        let project = try catalog.project(matching: SQLiteCatalog.ProjectQuery.named("Shopclass"))
+        XCTAssertThrowsError(try catalog.project(matching: GenericProjectQuery.named("class")))
+        let project = try catalog.project(matching: GenericProjectQuery.named("Shopclass"))
         XCTAssertEqual(project.id, .project2)
     }
     
@@ -166,24 +166,24 @@ final class CatalogQueryTests: _CatalogTestCase {
     }
     
     func testQueryExpressionsProjectID() throws {
-        let expressions = try catalog.expressions(matching: SQLiteCatalog.ExpressionQuery.projectID(.project3))
+        let expressions = try catalog.expressions(matching: GenericExpressionQuery.projectID(.project3))
         XCTAssertEqual(expressions.count, 2)
     }
     
     func testQueryExpressionsNamed() throws {
-        let expressions = try catalog.expressions(matching: SQLiteCatalog.ExpressionQuery.named("ull"))
+        let expressions = try catalog.expressions(matching: GenericExpressionQuery.named("ull"))
         XCTAssertEqual(expressions.count, 2)
     }
     
     func testQueryExpressionsHaving() throws {
-        var expressions = try catalog.expressions(matching: SQLiteCatalog.ExpressionQuery.having(.fr, nil, nil))
+        var expressions = try catalog.expressions(matching: GenericExpressionQuery.translationsHaving(.fr, nil, nil))
         XCTAssertEqual(expressions.count, 3)
-        expressions = try catalog.expressions(matching: SQLiteCatalog.ExpressionQuery.having(.fr, nil, .CA))
+        expressions = try catalog.expressions(matching: GenericExpressionQuery.translationsHaving(.fr, nil, .CA))
         XCTAssertEqual(expressions.count, 1)
     }
     
     func testQueryExpressionsHavingOnly() throws {
-        let expressions = try catalog.expressions(matching: SQLiteCatalog.ExpressionQuery.havingOnly(.fr))
+        let expressions = try catalog.expressions(matching: GenericExpressionQuery.translationsHavingOnly(.fr))
         XCTAssertEqual(expressions.count, 3)
     }
     
@@ -203,19 +203,19 @@ final class CatalogQueryTests: _CatalogTestCase {
     }
     
     func testQueryTranslationsExpressionId() throws {
-        let translations = try catalog.translations(matching: SQLiteCatalog.TranslationQuery.expressionID(.expression3))
+        let translations = try catalog.translations(matching: GenericTranslationQuery.expressionID(.expression3))
         XCTAssertEqual(translations.count, 3)
     }
     
     func testQueryTranslationsHaving() throws {
-        var translations = try catalog.translations(matching: SQLiteCatalog.TranslationQuery.having(.expression5, .fr, nil, nil))
+        var translations = try catalog.translations(matching: GenericTranslationQuery.having(.expression5, .fr, nil, nil))
         XCTAssertEqual(translations.count, 2)
-        translations = try catalog.translations(matching: SQLiteCatalog.TranslationQuery.having(.expression5, .fr, nil, .CA))
+        translations = try catalog.translations(matching: GenericTranslationQuery.having(.expression5, .fr, nil, .CA))
         XCTAssertEqual(translations.count, 1)
     }
     
     func testQueryTranslationsHavingOnly() throws {
-        let translations = try catalog.translations(matching: SQLiteCatalog.TranslationQuery.havingOnly(.expression5, .fr))
+        let translations = try catalog.translations(matching: GenericTranslationQuery.havingOnly(.expression5, .fr))
         XCTAssertEqual(translations.count, 1)
     }
     

--- a/Tests/TranslationCatalogSQLiteTests/CatalogUpdateTests.swift
+++ b/Tests/TranslationCatalogSQLiteTests/CatalogUpdateTests.swift
@@ -37,7 +37,7 @@ final class CatalogUpdateTests: _CatalogTestCase {
         
         let catalog = try SQLiteCatalog(url: url)
         try preConditions(catalog: catalog)
-        try catalog.updateProject(id, action: SQLiteCatalog.ProjectUpdate.name("Example-2"))
+        try catalog.updateProject(id, action: GenericProjectUpdate.name("Example-2"))
         try postConditions(catalog: catalog)
     }
     
@@ -53,13 +53,13 @@ final class CatalogUpdateTests: _CatalogTestCase {
         }
         
         func postConditions(catalog: SQLiteCatalog) throws {
-            let expressions = try catalog.expressions(matching: SQLiteCatalog.ExpressionQuery.projectID(projectId))
+            let expressions = try catalog.expressions(matching: GenericExpressionQuery.projectID(projectId))
             XCTAssertEqual(expressions.count, 1)
         }
         
         let catalog = try SQLiteCatalog(url: url)
         try preConditions(catalog: catalog)
-        try catalog.updateProject(projectId, action: SQLiteCatalog.ProjectUpdate.linkExpression(expressionId))
+        try catalog.updateProject(projectId, action: GenericProjectUpdate.linkExpression(expressionId))
         try postConditions(catalog: catalog)
     }
     
@@ -74,13 +74,13 @@ final class CatalogUpdateTests: _CatalogTestCase {
         }
         
         func postConditions(catalog: SQLiteCatalog) throws {
-            let expressions = try catalog.expressions(matching: SQLiteCatalog.ExpressionQuery.projectID(projectId))
+            let expressions = try catalog.expressions(matching: GenericExpressionQuery.projectID(projectId))
             XCTAssertEqual(expressions.count, 0)
         }
         
         let catalog = try SQLiteCatalog(url: url)
         try preConditions(catalog: catalog)
-        try catalog.updateProject(projectId, action: SQLiteCatalog.ProjectUpdate.unlinkExpression(expressionId))
+        try catalog.updateProject(projectId, action: GenericProjectUpdate.unlinkExpression(expressionId))
         try postConditions(catalog: catalog)
     }
     
@@ -99,7 +99,7 @@ final class CatalogUpdateTests: _CatalogTestCase {
         
         let catalog = try SQLiteCatalog(url: url)
         try preConditions(catalog: catalog)
-        try catalog.updateExpression(expressionId, action: SQLiteCatalog.ExpressionUpdate.key("KEY_ONE"))
+        try catalog.updateExpression(expressionId, action: GenericExpressionUpdate.key("KEY_ONE"))
         try postConditions(catalog: catalog)
     }
     
@@ -118,7 +118,7 @@ final class CatalogUpdateTests: _CatalogTestCase {
         
         let catalog = try SQLiteCatalog(url: url)
         try preConditions(catalog: catalog)
-        try catalog.updateExpression(expressionId, action: SQLiteCatalog.ExpressionUpdate.name("Example"))
+        try catalog.updateExpression(expressionId, action: GenericExpressionUpdate.name("Example"))
         try postConditions(catalog: catalog)
     }
     
@@ -137,7 +137,7 @@ final class CatalogUpdateTests: _CatalogTestCase {
         
         let catalog = try SQLiteCatalog(url: url)
         try preConditions(catalog: catalog)
-        try catalog.updateExpression(expressionId, action: SQLiteCatalog.ExpressionUpdate.defaultLanguage(.fr))
+        try catalog.updateExpression(expressionId, action: GenericExpressionUpdate.defaultLanguage(.fr))
         try postConditions(catalog: catalog)
     }
     
@@ -166,9 +166,9 @@ final class CatalogUpdateTests: _CatalogTestCase {
         
         let catalog = try SQLiteCatalog(url: url)
         try preConditions(catalog: catalog)
-        try catalog.updateExpression(id1, action: SQLiteCatalog.ExpressionUpdate.context("Common"))
-        try catalog.updateExpression(id2, action: SQLiteCatalog.ExpressionUpdate.context(nil))
-        try catalog.updateExpression(id3, action: SQLiteCatalog.ExpressionUpdate.context("General"))
+        try catalog.updateExpression(id1, action: GenericExpressionUpdate.context("Common"))
+        try catalog.updateExpression(id2, action: GenericExpressionUpdate.context(nil))
+        try catalog.updateExpression(id3, action: GenericExpressionUpdate.context("General"))
         try postConditions(catalog: catalog)
     }
     
@@ -197,9 +197,9 @@ final class CatalogUpdateTests: _CatalogTestCase {
         
         let catalog = try SQLiteCatalog(url: url)
         try preConditions(catalog: catalog)
-        try catalog.updateExpression(id1, action: SQLiteCatalog.ExpressionUpdate.feature("Common"))
-        try catalog.updateExpression(id2, action: SQLiteCatalog.ExpressionUpdate.feature(nil))
-        try catalog.updateExpression(id3, action: SQLiteCatalog.ExpressionUpdate.feature("General"))
+        try catalog.updateExpression(id1, action: GenericExpressionUpdate.feature("Common"))
+        try catalog.updateExpression(id2, action: GenericExpressionUpdate.feature(nil))
+        try catalog.updateExpression(id3, action: GenericExpressionUpdate.feature("General"))
         try postConditions(catalog: catalog)
     }
     
@@ -215,13 +215,13 @@ final class CatalogUpdateTests: _CatalogTestCase {
         }
         
         func postConditions(catalog: SQLiteCatalog) throws {
-            let expressions = try catalog.expressions(matching: SQLiteCatalog.ExpressionQuery.projectID(projectId))
+            let expressions = try catalog.expressions(matching: GenericExpressionQuery.projectID(projectId))
             XCTAssertEqual(expressions.count, 1)
         }
         
         let catalog = try SQLiteCatalog(url: url)
         try preConditions(catalog: catalog)
-        try catalog.updateExpression(expressionId, action: SQLiteCatalog.ExpressionUpdate.linkProject(projectId))
+        try catalog.updateProject(projectId, action: GenericProjectUpdate.linkExpression(expressionId))
         try postConditions(catalog: catalog)
     }
     
@@ -236,13 +236,13 @@ final class CatalogUpdateTests: _CatalogTestCase {
         }
         
         func postConditions(catalog: SQLiteCatalog) throws {
-            let expressions = try catalog.expressions(matching: SQLiteCatalog.ExpressionQuery.projectID(projectId))
+            let expressions = try catalog.expressions(matching: GenericExpressionQuery.projectID(projectId))
             XCTAssertEqual(expressions.count, 0)
         }
         
         let catalog = try SQLiteCatalog(url: url)
         try preConditions(catalog: catalog)
-        try catalog.updateExpression(expressionId, action: SQLiteCatalog.ExpressionUpdate.unlinkProject(projectId))
+        try catalog.updateProject(projectId, action: GenericProjectUpdate.unlinkExpression(expressionId))
         try postConditions(catalog: catalog)
     }
     
@@ -263,7 +263,7 @@ final class CatalogUpdateTests: _CatalogTestCase {
         
         let catalog = try SQLiteCatalog(url: url)
         try preConditions(catalog: catalog)
-        try catalog.updateTranslation(translationId, action: SQLiteCatalog.TranslationUpdate.language(.fr))
+        try catalog.updateTranslation(translationId, action: GenericTranslationUpdate.language(.fr))
         try postConditions(catalog: catalog)
     }
     
@@ -292,9 +292,9 @@ final class CatalogUpdateTests: _CatalogTestCase {
         
         let catalog = try SQLiteCatalog(url: url)
         try preConditions(catalog: catalog)
-        try catalog.updateTranslation(id1, action: SQLiteCatalog.TranslationUpdate.script(.Deva))
-        try catalog.updateTranslation(id2, action: SQLiteCatalog.TranslationUpdate.script(nil))
-        try catalog.updateTranslation(id3, action: SQLiteCatalog.TranslationUpdate.script(.Hant))
+        try catalog.updateTranslation(id1, action: GenericTranslationUpdate.script(.Deva))
+        try catalog.updateTranslation(id2, action: GenericTranslationUpdate.script(nil))
+        try catalog.updateTranslation(id3, action: GenericTranslationUpdate.script(.Hant))
         try postConditions(catalog: catalog)
     }
     
@@ -323,9 +323,9 @@ final class CatalogUpdateTests: _CatalogTestCase {
         
         let catalog = try SQLiteCatalog(url: url)
         try preConditions(catalog: catalog)
-        try catalog.updateTranslation(id1, action: SQLiteCatalog.TranslationUpdate.region(.AU))
-        try catalog.updateTranslation(id2, action: SQLiteCatalog.TranslationUpdate.region(nil))
-        try catalog.updateTranslation(id3, action: SQLiteCatalog.TranslationUpdate.region(.GB))
+        try catalog.updateTranslation(id1, action: GenericTranslationUpdate.region(.AU))
+        try catalog.updateTranslation(id2, action: GenericTranslationUpdate.region(nil))
+        try catalog.updateTranslation(id3, action: GenericTranslationUpdate.region(.GB))
         try postConditions(catalog: catalog)
     }
     
@@ -346,7 +346,7 @@ final class CatalogUpdateTests: _CatalogTestCase {
         
         let catalog = try SQLiteCatalog(url: url)
         try preConditions(catalog: catalog)
-        try catalog.updateTranslation(translationId, action: SQLiteCatalog.TranslationUpdate.value("Updated"))
+        try catalog.updateTranslation(translationId, action: GenericTranslationUpdate.value("Updated"))
         try postConditions(catalog: catalog)
     }
 }


### PR DESCRIPTION
Added concrete examples of queries and updates for the `Project`, `Expression`, and `Translation` entities.

Corrected issues with catalog imports and multiple languages.