### PR TITLE
Apple Platform Conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ import LocaleSupport
 
 This module is focused on implementing localized strings within apps themselves. Highlighted by the `ExpressibleByLocalizedString` protocol.
 
+**Apple Platforms Note**:
+
+As of `macOS 13`, `iOS 16`, `tvOS 16` & `watchOS 9`, the `Locale` type includes support for many of the extensions in this package:
+
+* `Locale.LanguageCode`
+* `Locale.Script`
+* `Locale.Region`
+* `Locale.Components`
+
 ## Contribution
 
 Contributions to **LocaleSupport** are welcomed and encouraged!

--- a/Sources/LocaleSupport/Locale+LocaleSupport.swift
+++ b/Sources/LocaleSupport/Locale+LocaleSupport.swift
@@ -15,7 +15,7 @@ public extension Locale {
         self.init(identifier: id)
     }
     
-    init(language: LanguageCode, script: ScriptCode? = nil, region: RegionCode? = nil) throws {
+    init(language: LocaleSupport.LanguageCode, script: ScriptCode? = nil, region: RegionCode? = nil) throws {
         var id: String = language.rawValue
         if let script = script {
             id += "-\(script.rawValue)"


### PR DESCRIPTION
Resolves a conflict with `LanguageCode` when compiling against the latest Apple SDKs.

As of `macOS 13`, `iOS 16`, `tvOS 16` & `watchOS 9`, the `Locale` type includes support for many of the extensions in this package:

 * `Locale.LanguageCode`
 * `Locale.Script`
 * `Locale.Region`
 * `Locale.Components`
